### PR TITLE
relationship inclusion improvements

### DIFF
--- a/src/JsonApiServer.php
+++ b/src/JsonApiServer.php
@@ -327,12 +327,10 @@ class JsonApiServer implements JsonApiInterface, LoggerAwareInterface
                             foreach ($included->relationships()->all() as $relationship) {
                                 $related->relationships()->set($relationship);
                             }
-                            
-                            $document->included()->set($related);
                         }
-                    } else {
-                        $document->included()->set($related);
                     }
+
+                    $document->included()->set($related);
                 }
 
                 $this->includeRelated($document, $related, $subRequest);

--- a/src/JsonApiServer.php
+++ b/src/JsonApiServer.php
@@ -319,8 +319,20 @@ class JsonApiServer implements JsonApiInterface, LoggerAwareInterface
             foreach ($relationship->related()->all() as $related) {
                 $this->removeUnrequestedAttributes($related, $subRequest);
 
-                if ($shouldIncludeRelationship && !$document->included()->has($related->type(), $related->id())) {
-                    $document->included()->set($related);
+                if ($shouldIncludeRelationship) {
+                    if ($document->included()->has($related->type(), $related->id())) {
+                        $included = $document->included()->get($related->type(), $related->id());
+
+                        if (!$included->relationships()->isEmpty()) {
+                            foreach ($included->relationships()->all() as $relationship) {
+                                $related->relationships()->set($relationship);
+                            }
+                            
+                            $document->included()->set($related);
+                        }
+                    } else {
+                        $document->included()->set($related);
+                    }
                 }
 
                 $this->includeRelated($document, $related, $subRequest);


### PR DESCRIPTION
In some cases we include the same entity multiple times. Depending from the inclusion order, sometimes the included entity is not the "real one", with the desired relationships/links. We have to check every instance of that single entity, and get the relationships from all of them, basically we need the most amount of data what we can get from the instances of that same included entity.